### PR TITLE
Add helper scripts for pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# sf-dbi-data-pipeline
+# SF DBI Data Pipeline
+
+This repository contains helper scripts for setting up R2 buckets and Cloudflare Pipelines used by the San Francisco Department of Building Inspection data workflow.
+
+## Requirements
+- [Node.js](https://nodejs.org) 18+
+- [`wrangler`](https://developers.cloudflare.com/workers/wrangler/) configured with your Cloudflare account credentials
+
+## Setup
+Install dependencies (none currently) and run the scripts using Node.js.
+
+```
+npm install
+```
+
+### Create R2 Buckets
+Run `scripts/create_r2_buckets.js` to create the required R2 buckets.
+
+```
+node scripts/create_r2_buckets.js
+```
+
+### Create Pipelines
+Run `scripts/create_pipelines.js` to create the Cloudflare Pipelines.
+
+```
+node scripts/create_pipelines.js
+```
+
+Both scripts simply wrap `wrangler` commands and will log errors if creation fails.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "sf-dbi-data-pipeline",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/scripts/create_pipelines.js
+++ b/scripts/create_pipelines.js
@@ -1,0 +1,35 @@
+const { execSync } = require('child_process');
+
+const pipelines = [
+  {
+    name: 'sf-permits-ingestion',
+    r2: 'sf-permits-data',
+    seconds: 60,
+    mb: 50,
+    shards: 3,
+  },
+  {
+    name: 'sf-permit-events',
+    r2: 'sf-permit-events',
+    seconds: 30,
+    mb: 25,
+    shards: 2,
+  },
+  {
+    name: 'sf-inspector-analytics',
+    r2: 'sf-inspector-data',
+    seconds: 300,
+    mb: 100,
+    shards: 1,
+  }
+];
+
+for (const p of pipelines) {
+  const cmd = `npx wrangler pipelines create ${p.name} --r2-bucket ${p.r2} --batch-max-seconds ${p.seconds} --batch-max-mb ${p.mb} --compression gzip --shard-count ${p.shards}`;
+  console.log(`Running: ${cmd}`);
+  try {
+    execSync(cmd, { stdio: 'inherit' });
+  } catch (err) {
+    console.error(`Failed to create pipeline ${p.name}:`, err.message);
+  }
+}

--- a/scripts/create_pipelines.js
+++ b/scripts/create_pipelines.js
@@ -31,5 +31,6 @@ for (const p of pipelines) {
     execSync(cmd, { stdio: 'inherit' });
   } catch (err) {
     console.error(`Failed to create pipeline ${p.name}:`, err.message);
+    console.error('Full error details:', err);
   }
 }

--- a/scripts/create_r2_buckets.js
+++ b/scripts/create_r2_buckets.js
@@ -11,7 +11,7 @@ for (const bucket of buckets) {
   const cmd = `npx wrangler r2 bucket create ${bucket}`;
   console.log(`Running: ${cmd}`);
   try {
-    const output = execSync(cmd, { stdio: 'inherit' });
+    execSync(cmd, { stdio: 'inherit' });
   } catch (err) {
     console.error(`Failed to create bucket ${bucket}:`, err.message);
   }

--- a/scripts/create_r2_buckets.js
+++ b/scripts/create_r2_buckets.js
@@ -13,6 +13,6 @@ for (const bucket of buckets) {
   try {
     execSync(cmd, { stdio: 'inherit' });
   } catch (err) {
-    console.error(`Failed to create bucket ${bucket}:`, err.message);
+    console.error(`Failed to create bucket ${bucket}:`, err);
   }
 }

--- a/scripts/create_r2_buckets.js
+++ b/scripts/create_r2_buckets.js
@@ -1,0 +1,18 @@
+const { execSync } = require('child_process');
+
+const buckets = [
+  'sf-permits-data',
+  'sf-permit-events',
+  'sf-inspector-data',
+  'sf-processed-files'
+];
+
+for (const bucket of buckets) {
+  const cmd = `npx wrangler r2 bucket create ${bucket}`;
+  console.log(`Running: ${cmd}`);
+  try {
+    const output = execSync(cmd, { stdio: 'inherit' });
+  } catch (err) {
+    console.error(`Failed to create bucket ${bucket}:`, err.message);
+  }
+}


### PR DESCRIPTION
## Summary
- document R2 bucket and pipeline setup in README
- add scripts to create Cloudflare R2 buckets and pipelines
- initialize npm package

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686375c004f8832e919c197cdac75d76